### PR TITLE
line break after printing the palette

### DIFF
--- a/palette.bash
+++ b/palette.bash
@@ -238,6 +238,7 @@ __palette.bash(){
 		fi
 		
 		echo -en "$output";
+		echo
 	} # palette.print end
 
 


### PR DESCRIPTION
Print a line break after printing the palette in the terminal.